### PR TITLE
Bug 1253495 - Validate data parsed from assertions before using it.

### DIFF
--- a/lib/primary.js
+++ b/lib/primary.js
@@ -16,6 +16,7 @@ config = require("./configuration.js"),
 primaryTimeout = config.get('declaration_of_support_timeout_ms'),
 secrets = require("./secrets.js"),
 events = require("events"),
+check = require('validator').check,
 wellKnownParser = require('./well-known-parser.js');
 
 // alg
@@ -146,26 +147,32 @@ var fetchWellKnown = function (currentDomain, principalDomain, clientCB) {
   // for browserid
   var httpProxy = config.has('http_proxy') ? config.get('http_proxy') : null;
 
-  var req;
-  if (httpProxy && httpProxy.port && httpProxy.host) {
-    // In production we use Squid as a reverse proxy cache to reduce how often
-    // we request this resource.
-    req = http.get({
-      host: httpProxy.host,
-      port: httpProxy.port,
-      path: 'https://' + currentDomain + WELL_KNOWN_URL + "?domain=" + principalDomain,
-      agent: false,
-      headers: {
-        host: currentDomain
-      }
-    }, handleResponse);
-  } else {
-    req = https.get({
-      host: currentDomain,
-      path: WELL_KNOWN_URL + "?domain=" + principalDomain,
-      rejectUnauthorized: true,
-      agent: false
-    }, handleResponse);
+  // The connection attempt can throw if there's e.g.
+  // unsupported characters in the domain name.
+  try {
+    var req;
+    if (httpProxy && httpProxy.port && httpProxy.host) {
+      // In production we use Squid as a reverse proxy cache to reduce how often
+      // we request this resource.
+      req = http.get({
+        host: httpProxy.host,
+        port: httpProxy.port,
+        path: 'https://' + currentDomain + WELL_KNOWN_URL + "?domain=" + principalDomain,
+        agent: false,
+        headers: {
+          host: currentDomain
+        }
+      }, handleResponse);
+    } else {
+      req = https.get({
+        host: currentDomain,
+        path: WELL_KNOWN_URL + "?domain=" + principalDomain,
+        rejectUnauthorized: false,
+        agent: false
+      }, handleResponse);
+    }
+  } catch (err) {
+    return cb('network connection error: ' + String(err));
   }
 
   // front-end shows xhr delay message after 10 sec; timeout sooner to avoid this
@@ -365,7 +372,11 @@ exports.verifyAssertion = function(assertion, cb) {
 
     // principal is in the last cert
     var principal = certParamsArray[certParamsArray.length - 1].certParams.principal;
-    var domainFromEmail = exports.domainFromEmail(principal.email);
+    try {
+      var domainFromEmail = exports.domainFromEmail(principal.email);
+    } catch (err) {
+      return cb("invalid email in assertion");
+    }
 
     if (rootIssuer !== domainFromEmail)
     {
@@ -385,5 +396,6 @@ exports.verifyAssertion = function(assertion, cb) {
 };
 
 exports.domainFromEmail = function domainFromEmail(email) {
+  check(email).isEmail();
   return EMAIL_REGEX.exec(email)[1].toLowerCase();
 };

--- a/lib/verifier/certassertion.js
+++ b/lib/verifier/certassertion.js
@@ -164,7 +164,11 @@ function verify(assertion, audience, forceIssuer, allowUnverified, successCB, er
         return errorCB("missing email");
       }
 
-      var domainFromEmail = primary.domainFromEmail(email);
+      try {
+        var domainFromEmail = primary.domainFromEmail(email);
+      } catch (err) {
+        return errorCB("invalid email");
+      }
 
       if (ultimateIssuer !== HOSTNAME &&
           ultimateIssuer !== domainFromEmail &&


### PR DESCRIPTION
Assertions are untrusted client-supplied data, they need to be
subject to the same precautions that we use elsewhere.
